### PR TITLE
Add Network Contributor role to fix #5

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ module "routetable" {
 resource "azurerm_kubernetes_cluster" "privateaks" {
   name                    = "private-aks"
   location                = var.location
-  kubernetes_version      = "1.16.9"
+  kubernetes_version      = "1.19.0"
   resource_group_name     = azurerm_resource_group.kube.name
   dns_prefix              = "private-aks"
   private_cluster_enabled = true
@@ -113,6 +113,12 @@ resource "azurerm_kubernetes_cluster" "privateaks" {
 resource "azurerm_role_assignment" "vmcontributor" {
   role_definition_name = "Virtual Machine Contributor"
   scope                = azurerm_resource_group.vnet.id
+  principal_id         = azurerm_kubernetes_cluster.privateaks.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "netcontributor" {
+  role_definition_name = "Network Contributor"
+  scope                = module.kube_network.subnet_ids["aks-subnet"]
   principal_id         = azurerm_kubernetes_cluster.privateaks.identity[0].principal_id
 }
 

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ module "routetable" {
 resource "azurerm_kubernetes_cluster" "privateaks" {
   name                    = "private-aks"
   location                = var.location
-  kubernetes_version      = "1.19.0"
+  kubernetes_version      = var.kube_version
   resource_group_name     = azurerm_resource_group.kube.name
   dns_prefix              = "private-aks"
   private_cluster_enabled = true
@@ -108,12 +108,6 @@ resource "azurerm_kubernetes_cluster" "privateaks" {
   }
 
   depends_on = [module.routetable]
-}
-
-resource "azurerm_role_assignment" "vmcontributor" {
-  role_definition_name = "Virtual Machine Contributor"
-  scope                = azurerm_resource_group.vnet.id
-  principal_id         = azurerm_kubernetes_cluster.privateaks.identity[0].principal_id
 }
 
 resource "azurerm_role_assignment" "netcontributor" {

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,11 @@ variable "kube_vnet_name" {
   default     = "spoke1-kubevnet"
 }
 
+variable "kube_version" {
+  description = "AKS Kubernetes version"
+  default     = "1.18.8"
+}
+
 variable "kube_resource_group_name" {
   description = "The resource group name to be created"
   default     = "nopublicipaks"


### PR DESCRIPTION
Adds the Network Contributor role assignment to the AKS SystemAssigned Identity. Fixes #5 

Also, bumps the version of Kubernetes (1.16 is now deprecated in West Europe).