### PR TITLE
Making K8S version more flexible (and robust)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,10 +80,15 @@ module "routetable" {
   subnet_id          = module.kube_network.subnet_ids["aks-subnet"]
 }
 
+data "azurerm_kubernetes_service_versions" "current" {
+  location       = var.location
+  version_prefix = var.kube_version_prefix
+}
+
 resource "azurerm_kubernetes_cluster" "privateaks" {
   name                    = "private-aks"
   location                = var.location
-  kubernetes_version      = var.kube_version
+  kubernetes_version      = data.azurerm_kubernetes_service_versions.current.latest_version
   resource_group_name     = azurerm_resource_group.kube.name
   dns_prefix              = "private-aks"
   private_cluster_enabled = true

--- a/variables.tf
+++ b/variables.tf
@@ -18,9 +18,9 @@ variable "kube_vnet_name" {
   default     = "spoke1-kubevnet"
 }
 
-variable "kube_version" {
-  description = "AKS Kubernetes version"
-  default     = "1.18.8"
+variable "kube_version_prefix" {
+  description = "AKS Kubernetes version prefix. Formatted '[Major].[Minor]' like '1.18'. Patch version part (as in '[Major].[Minor].[Patch]') will be set to latest automatically."
+  default     = "1.18"
 }
 
 variable "kube_resource_group_name" {


### PR DESCRIPTION
Patch versions (e.g. "1.18.8") are going out of support for new deployments rather quickly (see [docs](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions#kubernetes-version-support-policy)), so Terraform code like this with fixed default values for patch version becomes undeployable rather quickly (non-supported K8S version error).

This PR uses the azurerm_kubernetes_service_versions data source to retrieve the latest patch version at deploy time, which delays the default config becoming undeployable until the minor version (e.g. "1.18") will be deprecated, which takes much longer.