### PR TITLE
Whitelist client-IP for jumpbox VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ After you configure authentication with Azure, just init and apply (no inputs ar
 `terraform init`
 
 `terraform apply`
+
+# Connecting to the jumpbox VM
+During deployment, your IP where you deployed from is whitelisted in the `SSH` rule so that you (and only you) can SSH into the jumpbox VM.  In the future, if you're not able to ssh into the jumpbox VM, then check the `SSH` rule in your network security group to make sure your current IP address is whitelisted.

--- a/modules/jumpbox/main.tf
+++ b/modules/jumpbox/main.tf
@@ -1,3 +1,8 @@
+module myip {
+  source  = "4ops/myip/http"
+  version = "1.0.0"
+}
+
 resource "azurerm_public_ip" "pip" {
   name                = "vm-pip"
   location            = var.location
@@ -18,7 +23,7 @@ resource "azurerm_network_security_group" "vm_sg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "22"
-    source_address_prefix      = "*"
+    source_address_prefix      = module.myip.address
     destination_address_prefix = "*"
   }
 }


### PR DESCRIPTION
This PR limits the risk of having an SSH endpoint publicly exposed on the internet by whitelisting the client-ip where the solution is deployed from.  